### PR TITLE
Update pot3d.dat in isc2023

### DIFF
--- a/testsuite/isc2023/input/pot3d.dat
+++ b/testsuite/isc2023/input/pot3d.dat
@@ -24,7 +24,7 @@
   bpfile='bp.h5'
   br_photo_file=''
   ncghist=100
-  ncgmax=10000000
+  ncgmax=40000
   epscg=1.e-12
   idebug=0
  /


### PR DESCRIPTION
isc2023 input converged at 25112 steps.
I changed ncgmax to 40000 because I don’t want teams to waste too much time if something goes wrong with their builds.
