### PR TITLE
Fix plot2d scripts path error

### DIFF
--- a/scripts/psipals.py
+++ b/scripts/psipals.py
@@ -17,7 +17,7 @@ def load(N=1024):
             rgbdir="/tools/ps_rsrc/rgb_color_palettes/rgb/"
             ierr=1
         else:
-            rootdir="."
+            rootdir="./"
             rgbdir="psi_color_palettes/"
             ierr=1
     
@@ -29,9 +29,9 @@ def load(N=1024):
 
     if (ierr==1):
 # Loop over dat files, extract name and make colormaps.
-        for filename in os.listdir(rootdir+rgbdir):
+        for filename in os.listdir(os.path.join(rootdir, rgbdir)):
             if filename.endswith(".dat"):
-                pal_dat_file=os.path.join(rootdir+rgbdir, filename)
+                pal_dat_file=os.path.join(os.path.join(rootdir, rgbdir), filename)
                 cmap_name="psi_"+os.path.splitext(filename)[0]
                 pal = np.loadtxt(pal_dat_file)
             # Because of wierd IDL colormap format,


### PR DESCRIPTION
### Motivision:
When we use the use the psi_color_palettes under `./scripts` folder, the path seems not correct. `'/'` is missing.

Here is a full error log
```
Traceback (most recent call last):
  File "./scripts/psi_plot2d", line 770, in <module>
    main()
  File "./scripts/psi_plot2d", line 766, in main
    run(args)
  File "./scripts/psi_plot2d", line 354, in run
    psipals.load()
  File "./scripts/psipals.py", line 32, in load
    for filename in (rootdir+rgbdir):
FileNotFoundError: [Errno 2] No such file or directory: '.psi_color_palettes/'
```

### Modification
Edited `scripts/psipals.py`
1. Made `rootdir` in line20 from `"."` to `"./"`.
2. In order to make the code more robust, changed `(rootdir+rgbdir)`  to `os.path.join(rootdir, rgbdir)`.