### PR TITLE
Fix validation script when run fails in validation

### DIFF
--- a/scripts/pot3d_validation.sh
+++ b/scripts/pot3d_validation.sh
@@ -5,6 +5,7 @@ valid_run=$2
 
 cX="\033[0m"
 cG="\033[32m"
+cR="\033[31m"
 echo="echo -e"
 
 br1=$(grep "Energy in Br" $1)
@@ -41,13 +42,13 @@ else
   ${echo} "Run may have ${cR}FAILED${cX} validation!"
   echo " "
   echo "RUN1 BR: $br1"
-  echo "RUN2 BR: $br1"
+  echo "RUN2 BR: $br2"
   echo " "
   echo "RUN1 BT: $bt1"
-  echo "RUN2 BT: $bt1"
+  echo "RUN2 BT: $bt2"
   echo " "
   echo "RUN1 BP: $bp1"
-  echo "RUN2 BP: $bp1"
+  echo "RUN2 BP: $bp2"
 fi
 
 exit 0


### PR DESCRIPTION
### Motivation:
The validation script `scripts/pot3d_validation.sh` does not work properly when run fails in validation:
* Not show the word `FAILED` in red as expected.
* Not show the current result and expected result properly.

### Modification
Edited `scripts/pot3d_validation.sh` to fix the 2 issues above.